### PR TITLE
関連記事セクションの作成など

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -114,18 +114,20 @@ weight = 2
 #################### article ################################
 # 関連記事
 [related]
-  threshold = 0.1
-  toLower = true
   includeNewer = true
-  [[related.indices]]
-    name = "tags"
-    weight = 200
+  threshold = 60  # 閾値を下げる
+  toLower = false
+
   [[related.indices]]
     name = "categories"
     weight = 100
+
+  [[related.indices]]
+    name = "tags"
+    weight = 80
+
   [[related.indices]]
     name = "date"
-    pattern = "2006"
     weight = 10
 
 #################### default parameters ################################


### PR DESCRIPTION

## 詳細
1. 記事の下に「関連記事」を作成
   - 閾値を調整（0.1 → 60）

2. Notion記事をダウンロードする際に、下書き記事をスキップする機能を追加

3. 目次のデザイン変更

## 参考
- Hugo関連記事機能のドキュメント: https://gohugo.io/content-management/related/
